### PR TITLE
How-to-move-the-next-cell-into-edit-mode-by-pressing-the-tab-key-in-Flutter-DataTable-SfDataGrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ class CustomSelectionManager extends RowSelectionManager {
   CustomSelectionManager(this.dataGridController);
   DataGridController dataGridController;
   @override
-  void handleKeyEvent(RawKeyEvent keyEvent) async {
+  Future<void> handleKeyEvent(RawKeyEvent keyEvent) async {
     if (keyEvent.logicalKey == LogicalKeyboardKey.tab) {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         dataGridController.beginEdit(dataGridController.currentCell);
@@ -67,8 +67,8 @@ class EmployeeDataSource extends DataGridSource {
   }
 
   @override
-  void onCellSubmit(DataGridRow dataGridRow, RowColumnIndex rowColumnIndex,
-      GridColumn column) {
+  Future<void> onCellSubmit(DataGridRow dataGridRow, RowColumnIndex rowColumnIndex,
+      GridColumn column) async {
     final dynamic oldValue = dataGridRow
             .getCells()
             .firstWhereOrNull((DataGridCell dataGridCell) =>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,7 +77,7 @@ class CustomSelectionManager extends RowSelectionManager {
   CustomSelectionManager(this.dataGridController);
   DataGridController dataGridController;
   @override
-  void handleKeyEvent(RawKeyEvent keyEvent) async {
+  Future<void> handleKeyEvent(RawKeyEvent keyEvent) async {
     if (keyEvent.logicalKey == LogicalKeyboardKey.tab) {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         dataGridController.beginEdit(dataGridController.currentCell);
@@ -129,8 +129,8 @@ class EmployeeDataSource extends DataGridSource {
   }
 
   @override
-  void onCellSubmit(DataGridRow dataGridRow, RowColumnIndex rowColumnIndex,
-      GridColumn column) {
+  Future<void> onCellSubmit(DataGridRow dataGridRow,
+      RowColumnIndex rowColumnIndex, GridColumn column) async {
     final dynamic oldValue = dataGridRow
             .getCells()
             .firstWhereOrNull((DataGridCell dataGridCell) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  syncfusion_flutter_datagrid: 20.4.38
+  syncfusion_flutter_datagrid: ^22.1.39
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Description ##

- Modified the sample for "How-to-move-the-next-cell-into-edit-mode-by-pressing-the-tab-key-in-Flutter-DataTable-SfDataGrid."